### PR TITLE
Added support for multiple metrics/dimensions per request

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -116,10 +116,10 @@ GA.prototype.get = function(options, cb) {
         });
         res.on('end', function() {
             var entries = []
-            ,metric_index
-            ,metric
-            ,dimension
-            ,dimension_index;
+            ,metric_indexes = []
+            ,metrics = []
+            ,dimensions = []
+            ,dimension_indexes = [];
 
             var data_data = combineChunks(chunks, length).toString();
             
@@ -129,12 +129,12 @@ GA.prototype.get = function(options, cb) {
 
             for (var col=0; col<parsed_data.columnHeaders.length; col++){
                 if(parsed_data.columnHeaders[col]['columnType'] === "METRIC"){
-                    metric_index = col;
-                    metric = parsed_data.columnHeaders[col];
+                    metric_indexes.push(col);
+                    metrics.push(parsed_data.columnHeaders[col]);
                 }
                 if(parsed_data.columnHeaders[col]['columnType'] === "DIMENSION"){
-                    dimension_index = col;
-                    dimension = parsed_data.columnHeaders[col];
+                    dimension_indexes.push(col);
+                    dimensions.push(parsed_data.columnHeaders[col]);
                 }
             }
 
@@ -143,11 +143,15 @@ GA.prototype.get = function(options, cb) {
                 var entry = {metrics:[], dimensions:[]};
 
                 var object_metric = {};
-                object_metric[metric.name] = parseInt(parsed_data.rows[i][metric_index], 10);
+                for (var j=0; j<dimensions.length; j++){
+                    object_metric[metrics[j].name] = parseInt(parsed_data.rows[i][metric_indexes[j]], 10);
+                }
                 entry.metrics.push(object_metric);
 
                 var object_dimension = {};
-                object_dimension[dimension.name] = parsed_data.rows[i][dimension_index];
+                for (var j=0; j<dimensions.length; j++){
+                    object_dimension[dimensions[j].name] = parsed_data.rows[i][dimension_indexes[j]];
+                }
                 entry.dimensions.push(object_dimension);
 
                 self.emit('entry', entry);


### PR DESCRIPTION
Library was accepting multiple metrics/dimensions in each request, but not parsing/returning the additional data (only the first value of each was being parsed).
