### PR TITLE
Fix for scientific notation metric results

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -160,7 +160,7 @@ GA.prototype.get = function(options, cb) {
 
                 var object_metric = {};
                 for (var j=0; j<metrics.length; j++){
-                    object_metric[metrics[j].name] = parseInt(parsed_data.rows[i][metric_indexes[j]], 10);
+                    object_metric[metrics[j].name] = parseFloat(parsed_data.rows[i][metric_indexes[j]]);
                 }
                 entry.metrics.push(object_metric);
 


### PR DESCRIPTION
Changed from parseInt to parseFloat.

`Note:` This will start producing larger decimals as they aren't being rounded any more.

issue #28
