### PR TITLE
Add support for realtime API

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -101,7 +101,8 @@ GA.prototype.login = function(cb) {
 GA.prototype.get = function(options, cb) {
     var self = this;
 
-    var data_url = "/analytics/v3/data/ga?" + querystring.stringify(options);
+    var rt = (options.metrics.lastIndexOf('rt:',0) === 0 ? true : false);
+    var data_url = "/analytics/v3/data/" + (rt ? "realtime?" : "ga?") + querystring.stringify(options);
 
     var get_options = {
         host: 'www.googleapis.com',


### PR DESCRIPTION
Detect usage of realtime API via options.metrics field and automatically use the Google Analytics realtime API endpoint instead of "ga" endpoint.
