### PR TITLE
Issue 33 - Handle login errors

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -81,7 +81,15 @@ GA.prototype.login = function(cb) {
             var data = combineChunks(chunks, length).toString();
             var m = data.match(/(Auth=[^\s]*)\s/);
             if (!m) {
-                self.emit('error', data);
+                m = data.match(/(Error=[^\s]*)\s/);
+                if(m) {
+                    var errMessage = m[0].replace('Error=', '');
+                    var err = new Error(errMessage);
+                    err.responseData = data;
+                    self.emit('token', err, null);   
+                } else {
+                    self.emit('error', data);
+                }
             } else {
                 self.emit('token', null, m[1]);
             }


### PR DESCRIPTION
If the response has an Error= match then create a new error with this message and pass to the call back.  I have also included the response data in the error for more info.
