### PR TITLE
Pass back total results to callback

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -187,7 +187,8 @@ GA.prototype.get = function(options, cb) {
 
             }
 
-            if (typeof cb === 'function' ) cb(null, entries);
+	    parsed_data.totalResults = parsed_data.totalResults || 0;
+            if (typeof cb === 'function' ) cb(null, entries, parsed_data.totalResults);
                 
         });
     });


### PR DESCRIPTION
I've run into several situations where I need to return more than the 10,000 result limit from the API.  The API supports passing a 'start-index' option in the request and going beyond on the 10,000 result limit.

Unfortunately, the callback function is never told the total number of results available so that it can make more calls (incrementing start-index each time) if necessary.

These changes will allow for totalResults to be passed back and also will no break existing implementations.